### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:15.0.1-alpine3.10
 
 RUN mkdir -p /usr/src/app
 
@@ -13,4 +13,4 @@ COPY . /usr/src/app
 
 EXPOSE 8081  
 RUN npm install  
-CMD ["npm", "start"] 
+CMD ["node", "server.js"]


### PR DESCRIPTION
Running a container complains about missing "start" script. Presumably something changed in NPM to make this no longer work. Executing the server.js script directly instead.

Also pinning the node:alpine version.