### PR TITLE
Update Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.0.1-alpine3.10
+FROM FROM gcr.io/cloudacademy-labs-support/node:15.0.1-alpine3.10
 
 RUN mkdir -p /usr/src/app
 


### PR DESCRIPTION
Moving base image away from DockerHub due to rate limits on anonymous users

I've updated the ecslabblue.zip and ecslabgreen.zip assets in the calabsmaster assets bucket.